### PR TITLE
Webhook processing: 202 response with empty body

### DIFF
--- a/authorisation-adjustment-example/src/main/java/com/adyen/checkout/api/WebhookController.java
+++ b/authorisation-adjustment-example/src/main/java/com/adyen/checkout/api/WebhookController.java
@@ -42,7 +42,7 @@ public class WebhookController {
 
     /**
      * Process incoming Webhook notification: get NotificationRequestItem, validate HMAC signature,
-     * consume the event asynchronously, send response ["accepted"]
+     * consume the event asynchronously, send response status 202
      *
      * @param json Payload of the webhook event
      * @return
@@ -71,24 +71,25 @@ public class WebhookController {
                     consumeEvent(item);
 
                 } else {
-                    // invalid HMAC signature: do not send [accepted] response
+                    // invalid HMAC signature
                     log.warn("Could not validate HMAC signature for incoming webhook message: {}", item);
                     throw new RuntimeException("Invalid HMAC signature");
                 }
             } catch (SignatureException e) {
-                // Unexpected error during HMAC validation: do not send [accepted] response
+                // Unexpected error during HMAC validation
                 log.error("Error while validating HMAC Key", e);
                 throw new SignatureException(e);
             }
 
         } else {
-            // Unexpected event with no payload: do not send [accepted] response
+            // Unexpected event with no payload
             log.warn("Empty NotificationItem");
-            throw new Exception("empty");
+            throw new Exception("empty payload");
         }
 
         // Acknowledge event has been consumed
-        return ResponseEntity.ok().body("[accepted]");
+        return ResponseEntity.status(HttpStatus.ACCEPTED).build();
+
     }
 
     // process payload asynchronously

--- a/checkout-example-advanced/src/main/java/com/adyen/checkout/api/WebhookResource.java
+++ b/checkout-example-advanced/src/main/java/com/adyen/checkout/api/WebhookResource.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,7 +40,7 @@ public class WebhookResource {
 
     /**
      * Process incoming Webhook notification: get NotificationRequestItem, validate HMAC signature,
-     * consume the event asynchronously, send response ["accepted"]
+     * consume the event asynchronously, send response status 202
      *
      * @param json Payload of the webhook event
      * @return
@@ -70,24 +71,24 @@ public class WebhookResource {
                     consumeEvent(item);
 
                 } else {
-                    // invalid HMAC signature: do not send [accepted] response
+                    // invalid HMAC signature
                     log.warn("Could not validate HMAC signature for incoming webhook message: {}", item);
                     throw new RuntimeException("Invalid HMAC signature");
                 }
             } catch (SignatureException e) {
-                // Unexpected error during HMAC validation: do not send [accepted] response
+                // Unexpected error during HMAC validation
                 log.error("Error while validating HMAC Key", e);
                 throw new SignatureException(e);
             }
 
         } else {
-            // Unexpected event with no payload: do not send [accepted] response
+            // Unexpected event with no payload
             log.warn("Empty NotificationItem");
-            throw new Exception("empty");
+            throw new Exception("empty payload");
         }
 
         // Acknowledge event has been consumed
-        return ResponseEntity.ok().body("[accepted]");
+        return ResponseEntity.status(HttpStatus.ACCEPTED).build();
     }
 
     // process payload asynchronously

--- a/checkout-example/src/main/java/com/adyen/checkout/api/WebhookResource.java
+++ b/checkout-example/src/main/java/com/adyen/checkout/api/WebhookResource.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,7 +40,7 @@ public class WebhookResource {
 
     /**
      * Process the incoming Webhook event: get NotificationRequestItem, validate HMAC signature,
-     * consume the event asynchronously, send response ["accepted"]
+     * consume the event asynchronously, send response status 202
      *
      * @param json Payload of the webhook event
      * @return
@@ -69,24 +70,24 @@ public class WebhookResource {
                     consumeEvent(item);
 
                 } else {
-                    // invalid HMAC signature: do not send [accepted] response
+                    // invalid HMAC signature
                     log.warn("Could not validate HMAC signature for incoming webhook message: {}", item);
                     throw new RuntimeException("Invalid HMAC signature");
                 }
             } catch (SignatureException e) {
-                // Unexpected error during HMAC validation: do not send [accepted] response
+                // Unexpected error during HMAC validation
                 log.error("Error while validating HMAC Key", e);
                 throw new SignatureException(e);
             }
 
         } else {
-            // Unexpected event with no payload: do not send [accepted] response
+            // Unexpected event with no payload
             log.warn("Empty NotificationItem");
-            throw new Exception("empty");
+            throw new Exception("Event with empty payload");
         }
 
         // Acknowledge event has been consumed
-        return ResponseEntity.ok().body("[accepted]");
+        return ResponseEntity.status(HttpStatus.ACCEPTED).build();
     }
 
     // process payload asynchronously

--- a/giving-example/src/main/java/com/adyen/giving/api/GivingWebhookResource.java
+++ b/giving-example/src/main/java/com/adyen/giving/api/GivingWebhookResource.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -66,12 +67,12 @@ public class GivingWebhookResource {
                 consumeEvent(item);
 
         } else {
-            // Unexpected event with no payload: do not send [accepted] response
+            // Unexpected event with no payload
             log.warn("Empty NotificationItem");
         }
 
         // Acknowledge event has been consumed
-        return ResponseEntity.ok().body("[accepted]");
+        return ResponseEntity.status(HttpStatus.ACCEPTED).build();
     }
 
     // process payload asynchronously

--- a/giving-example/src/main/java/com/adyen/giving/api/WebhookResource.java
+++ b/giving-example/src/main/java/com/adyen/giving/api/WebhookResource.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,7 +40,7 @@ public class WebhookResource {
 
     /**
      * Process incoming Webhook notification: get NotificationRequestItem, validate HMAC signature,
-     * consume the event asynchronously, send response ["accepted"]
+     * consume the event asynchronously, send response status 202
      *
      * @param json Payload of the webhook event
      * @return
@@ -70,24 +71,24 @@ public class WebhookResource {
                     consumeEvent(item);
 
                 } else {
-                    // invalid HMAC signature: do not send [accepted] response
+                    // invalid HMAC signature
                     log.warn("Could not validate HMAC signature for incoming webhook message: {}", item);
                     throw new RuntimeException("Invalid HMAC signature");
                 }
             } catch (SignatureException e) {
-                // Unexpected error during HMAC validation: do not send [accepted] response
+                // Unexpected error during HMAC validation
                 log.error("Error while validating HMAC Key", e);
                 throw new SignatureException(e);
             }
 
         } else {
-            // Unexpected event with no payload: do not send [accepted] response
+            // Unexpected event with no payload
             log.warn("Empty NotificationItem");
-            throw new Exception("empty");
+            throw new Exception("empty payload");
         }
 
         // Acknowledge event has been consumed
-        return ResponseEntity.ok().body("[accepted]");
+        return ResponseEntity.status(HttpStatus.ACCEPTED).build();
     }
 
     // process payload asynchronously

--- a/in-person-payments-example/src/main/java/com/adyen/ipp/api/WebhookController.java
+++ b/in-person-payments-example/src/main/java/com/adyen/ipp/api/WebhookController.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,7 +35,7 @@ public class WebhookController {
 
     /**
      * Process the incoming Webhook event: get NotificationRequestItem, validate HMAC signature,
-     * consume the event asynchronously, send response ["accepted"]
+     * consume the event asynchronously, send response status 202
      *
      *  @param json Payload of the webhook event
      * @return
@@ -54,7 +55,7 @@ public class WebhookController {
 
             try {
                 if (!getHmacValidator().validateHMAC(item, this.applicationProperty.getHmacKey())) {
-                    // invalid HMAC signature: do not send [accepted] response
+                    // invalid HMAC signature
                     log.warn("Could not validate HMAC signature for incoming webhook message: {}", item);
                     throw new RuntimeException("Invalid HMAC signature");
                 }
@@ -85,7 +86,7 @@ public class WebhookController {
                 }
 
             } catch (SignatureException e) {
-                // Unexpected error during HMAC validation: do not send [accepted] response
+                // Unexpected error during HMAC validation
                 log.error("Error while validating HMAC Key", e);
                 throw new RuntimeException(e.getMessage());
             }
@@ -93,7 +94,7 @@ public class WebhookController {
         }
 
         // Acknowledge event has been consumed
-        return ResponseEntity.ok().body("[accepted]");
+        return ResponseEntity.status(HttpStatus.ACCEPTED).build();
     }
 
     @Bean

--- a/paybylink-example/src/main/java/com/adyen/paybylink/api/WebhookController.java
+++ b/paybylink-example/src/main/java/com/adyen/paybylink/api/WebhookController.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,7 +41,7 @@ public class WebhookController {
 
     /** Process incoming Webhook event: get NotificationRequestItem, validate HMAC signature,
      * Process the incoming Webhook: get NotificationRequestItem, validate HMAC signature,
-     * consume the event asynchronously, send response ["accepted"]
+     * consume the event asynchronously, send response status 202
      *
      *  @param json Payload of the webhook event
      * @return
@@ -70,24 +71,24 @@ public class WebhookController {
                     consumeEvent(item);
 
                 } else {
-                    // invalid HMAC signature: do not send [accepted] response
+                    // invalid HMAC signature
                     log.warn("Could not validate HMAC signature for incoming webhook message: {}", item);
                     throw new RuntimeException("Invalid HMAC signature");
                 }
             } catch (SignatureException e) {
-                // Unexpected error during HMAC validation: do not send [accepted] response
+                // Unexpected error during HMAC validation
                 log.error("Error while validating HMAC Key", e);
                 throw new SignatureException(e);
             }
 
         } else {
-            // Unexpected event with no payload: do not send [accepted] response
+            // Unexpected event with no payload
             log.warn("Empty NotificationItem");
             throw new Exception("empty");
         }
 
         // Acknowledge event has been consumed
-        return ResponseEntity.ok().body("[accepted]");
+        return ResponseEntity.status(HttpStatus.ACCEPTED).build();
     }
 
     // process payload asynchronously

--- a/subscription-example/src/main/java/com/adyen/checkout/api/WebhookResource.java
+++ b/subscription-example/src/main/java/com/adyen/checkout/api/WebhookResource.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,7 +38,7 @@ public class WebhookResource {
 
     /**
      * Process the incoming Webhook event: get NotificationRequestItem, validate HMAC signature,
-     * consume the event asynchronously, send response ["accepted"]
+     * consume the event asynchronously, send response status 202
      *
      *  @param json Payload of the webhook event
      * @return
@@ -57,7 +58,7 @@ public class WebhookResource {
 
             try {
                 if (!getHmacValidator().validateHMAC(item, this.applicationProperty.getHmacKey())) {
-                    // invalid HMAC signature: do not send [accepted] response
+                    // invalid HMAC signature
                     log.warn("Could not validate HMAC signature for incoming webhook message: {}", item);
                     throw new RuntimeException("Invalid HMAC signature");
                 }
@@ -86,7 +87,7 @@ public class WebhookResource {
                 }
 
             } catch (SignatureException e) {
-                // Unexpected error during HMAC validation: do not send [accepted] response
+                // Unexpected error during HMAC validation
                 log.error("Error while validating HMAC Key", e);
                 throw new RuntimeException(e.getMessage());
             }
@@ -94,7 +95,7 @@ public class WebhookResource {
         }
 
         // Acknowledge event has been consumed
-        return ResponseEntity.ok().body("[accepted]");
+        return ResponseEntity.status(HttpStatus.ACCEPTED).build();
     }
 
 


### PR DESCRIPTION
The latest approach to accepting webhooks requires sending the response code `202` and an empty response body.

This PR updates all webhook handlers to implement the new approach.